### PR TITLE
Update getting-started-in-5-minutes.md

### DIFF
--- a/docs/get-started/getting-started-in-5-minutes.md
+++ b/docs/get-started/getting-started-in-5-minutes.md
@@ -88,8 +88,8 @@ license = "GPL-3.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-gcore = { path = "https://github.com/gear-tech/gear.git", features = ["debug"] }
-gstd = { path = "https://github.com/gear-tech/gear.git", features = ["debug"] }
+gcore = { git = "https://github.com/gear-tech/gear.git", features = ["debug"] }
+gstd = { git = "https://github.com/gear-tech/gear.git", features = ["debug"] }
 
 [profile.release]
 lto = true


### PR DESCRIPTION
'git' instead of 'path' for `Cargo.toml` example.

Rendered: https://wiki.gear-tech.io/pr-13/
