### PR TITLE
Fix typo

### DIFF
--- a/docs/developing-contracts/examples/erc20.md
+++ b/docs/developing-contracts/examples/erc20.md
@@ -196,7 +196,7 @@ pub struct TransferFromReply {
     fn decrease_total_supply(&mut self, amount: u128)
 
     /// Executed on receiving `fungible-token-message::BalanceOf`, returns token balance of `account`.
-    fn balance_of(&self, account: &ActorI
+    fn balance_of(&self, account: &ActorId)
 ```
 
 ## Gear's example of ERC-20


### PR DESCRIPTION
line199: fn balance_of(&self, account: &ActorId)  instead of "fn balance_of(&self, account: &ActorI"

Updated sections:

-
-
-
