### PR TITLE
Fix a code error in erc20 contract demo

### DIFF
--- a/docs/developing-contracts/examples/erc20.md
+++ b/docs/developing-contracts/examples/erc20.md
@@ -197,12 +197,6 @@ pub struct TransferFromReply {
 
     /// Executed on receiving `fungible-token-message::BalanceOf`, returns token balance of `account`.
     fn balance_of(&self, account: &ActorId)
-    
-    /// Set the balance of an account.
-    fn set_balance(&mut self, account: &ActorId, amount: u128)
-    
-    /// Get the balance of an account.
-    fn get_balance(&self, account: &ActorId) -> u128
 ```
 
 ## Gear's example of ERC-20

--- a/docs/developing-contracts/examples/erc20.md
+++ b/docs/developing-contracts/examples/erc20.md
@@ -143,7 +143,8 @@ pub struct TransferFromReply {
     pub sender: ActorId,
     pub recipient: ActorId,
     pub amount: u128,
-    pub new_limit:
+    pub new_limit: u128
+}
 ```
 
 ## ERC-20 functions

--- a/docs/developing-contracts/examples/erc20.md
+++ b/docs/developing-contracts/examples/erc20.md
@@ -196,7 +196,13 @@ pub struct TransferFromReply {
     fn decrease_total_supply(&mut self, amount: u128)
 
     /// Executed on receiving `fungible-token-message::BalanceOf`, returns token balance of `account`.
-    fn balance_of(&self, account: &ActorId
+    fn balance_of(&self, account: &ActorId)
+    
+    /// Set the balance of an account.
+    fn set_balance(&mut self, account: &ActorId, amount: u128)
+    
+    /// Get the balance of an account.
+    fn get_balance(&self, account: &ActorId) -> u128
 ```
 
 ## Gear's example of ERC-20

--- a/docs/developing-contracts/examples/erc20.md
+++ b/docs/developing-contracts/examples/erc20.md
@@ -196,7 +196,7 @@ pub struct TransferFromReply {
     fn decrease_total_supply(&mut self, amount: u128)
 
     /// Executed on receiving `fungible-token-message::BalanceOf`, returns token balance of `account`.
-    fn balance_of(&self, account: &ActorI
+    fn balance_of(&self, account: &ActorId
 ```
 
 ## Gear's example of ERC-20

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/developing-contracts/examples/erc20.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/developing-contracts/examples/erc20.md
@@ -199,10 +199,4 @@ pub struct TransferFromReply {
 
     /// Executed on receiving `fungible-token-message::BalanceOf`, returns token balance of `account`.
     fn balance_of(&self, account: &ActorId)
-    
-    /// Set the balance of an account.
-    fn set_balance(&mut self, account: &ActorId, amount: u128)
-    
-    /// Get the balance of an account.
-    fn get_balance(&self, account: &ActorId) -> u128
 ```

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/developing-contracts/examples/erc20.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/developing-contracts/examples/erc20.md
@@ -198,5 +198,11 @@ pub struct TransferFromReply {
     fn decrease_total_supply(&mut self, amount: u128)
 
     /// Executed on receiving `fungible-token-message::BalanceOf`, returns token balance of `account`.
-    fn balance_of(&self, account: &ActorI
+    fn balance_of(&self, account: &ActorId)
+    
+    /// Set the balance of an account.
+    fn set_balance(&mut self, account: &ActorId, amount: u128)
+    
+    /// Get the balance of an account.
+    fn get_balance(&self, account: &ActorId) -> u128
 ```

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/developing-contracts/examples/erc20.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/developing-contracts/examples/erc20.md
@@ -145,7 +145,8 @@ pub struct TransferFromReply {
     pub sender: ActorId,
     pub recipient: ActorId,
     pub amount: u128,
-    pub new_limit:
+    pub new_limit: u128
+}
 ```
 
 # ERC-20 函数


### PR DESCRIPTION
Updated sections:

- This type is misspelled  fn balance_of(&self, account: &ActorI -> fn balance_of(&self, account: &ActorId
