### PR TITLE
Update the escrow smart contract example

### DIFF
--- a/docs/examples/escrow.md
+++ b/docs/examples/escrow.md
@@ -6,7 +6,7 @@ sidebar_position: 8
 # What is an escrow?
 An escrow is a special account to which some assets (e.g. money or stocks) are deposited and stored until certain conditions are met. In terms of smart contracts, an escrow is an account that is stored on a blockchain and, like a regular escrow, can receive some assets (e.g. a cryptocurrency or tokens) from one user and, when certain conditions are met, send them to another.
 
-This article will show the example of an escrow smart contract, where assets will be [Gear fungible tokens - GFT](/developing-contracts/examples/gft-20).
+This article will show the example of an escrow smart contract, where assets will be [Gear fungible tokens - GFT](/examples/gft-20).
 
 ## Logic
 * Any user can create an escrow account as its buyer or seller.

--- a/docs/examples/escrow.md
+++ b/docs/examples/escrow.md
@@ -35,10 +35,16 @@ enum AccountState {
 ```
 
 ## Interface
+### Type aliases
+```rust
+/// Escrow account ID.
+type AccountId = U256;
+```
+
 ### Initialization config
 ```rust
 pub struct InitEscrow {
-    // Address of a fungible token program.
+    /// Address of a fungible token program.
     pub ft_program_id: ActorId,
 }
 ```

--- a/docs/examples/escrow.md
+++ b/docs/examples/escrow.md
@@ -24,7 +24,7 @@ struct Wallet {
 }
 ```
 
-`WalletState` is the enum that stores a current state of a wallet:
+`WalletState` is an enum that stores a current state of a wallet:
 ```rust
 enum WalletState {
     AwaitingDeposit,
@@ -129,7 +129,7 @@ enum EscrowStateReply {
 ```
 
 ### Actions & events
-**Action** is the enum that is sent to a program and contains info about what it should do. After a successful processing of **Action**, a program replies with the **Event** enum that contains info about a processed **Action** and its result.
+**Action** is an enum that is sent to a program and contains info about what it should do. After a successful processing of **Action**, a program replies with the **Event** enum that contains info about a processed **Action** and its result.
 
 ```rust
 enum EscrowAction {

--- a/docs/examples/escrow.md
+++ b/docs/examples/escrow.md
@@ -4,46 +4,53 @@ sidebar_position: 8
 ---
 
 # What is an escrow?
-An escrow is a special account to which some assets (e.g. money or stocks) are deposited and stored until certain conditions are met. In terms of smart contracts, an escrow is a program that is stored on a blockchain and, like a regular escrow, can receive some assets (e.g. a cryptocurrency or tokens) from one user and, when certain conditions are met, send them to another.
+An escrow is a special account to which some assets (e.g. money or stocks) are deposited and stored until certain conditions are met. In terms of smart contracts, an escrow is an account that is stored on a blockchain and, like a regular escrow, can receive some assets (e.g. a cryptocurrency or tokens) from one user and, when certain conditions are met, send them to another.
 
-This article will show the example of an escrow smart contract, where assets will be [Gear fungible tokens - GFT](https://wiki.gear-tech.io/developing-contracts/examples/gft-20).
+This article will show the example of an escrow smart contract, where assets will be [Gear fungible tokens - GFT](/developing-contracts/examples/gft-20).
 
 ## Logic
-* Any user can create a contract as a buyer or seller.
-* A buyer can make a deposit and confirm a contract.
-* A seller can refund tokens from a paid contract to a buyer.
-* Both buyer and seller can cancel an unpaid contract.
+* Any user can create an escrow account as its buyer or seller.
+* The buyer can make a deposit to or confirm an account.
+* The seller can refund tokens from a paid account to the buyer.
+* Both buyer and seller can cancel an unpaid account.
 
-One escrow contract contains info about a `buyer`, a `seller`, their `state` and an `amount` of tokens that this contract can store:
+One escrow account contains info about a `buyer`, a `seller`, their `state` and an `amount` of tokens that this account can store:
 
 ```rust
-struct Contract {
+struct Account {
     buyer: ActorId,
     seller: ActorId,
-    state: State,
+    state: AccountState,
     amount: u128,
 }
 ```
 
-`State` is an enum that stores a current state of a contract:
+`AccountState` is an enum that stores a current state of an account:
 ```rust
-enum State {
+enum AccountState {
     AwaitingDeposit,
     AwaitingConfirmation,
-    Completed,
+    Closed,
 }
 ```
 
 ## Interface
+### Initialization config
+```rust
+pub struct InitEscrow {
+    // Address of a fungible token program.
+    pub ft_program_id: ActorId,
+}
+```
+
 ### Functions
 ```rust
 fn create(&mut self, buyer: ActorId, seller: ActorId, amount: u128)
 ```
-
-Creates one escrow contract and replies with an ID of this created contract.
+Creates one escrow account and replies with its ID.
 
 Requirements:
-* `msg::source()` must be a buyer or seller for this contract.
+* `msg::source()` must be a buyer or seller for the account.
 
 Arguments:
 * `buyer`: a buyer.
@@ -51,88 +58,90 @@ Arguments:
 * `amount`: an amount of tokens.
 
 ```rust
-async fn deposit(&mut self, contract_id: u128)
+async fn deposit(&mut self, account_id: U256)
 ```
-
 Makes a deposit from a buyer to an escrow account
-and changes a contract state to `AwaitingConfirmation`.
+and changes an account state to `AwaitingConfirmation`.
 
 Requirements:
-* `msg::source()` must be a buyer saved in a contract.
-* Contract must not be paid or completed.
+* `msg::source()` must be a buyer saved in the account.
+* An account must not be paid or closed.
 
 Arguments:
-* `contract_id`: a contract ID.
+* `account_id`: an account ID.
 
 ```rust
-async fn confirm(&mut self, contract_id: u128)
+async fn confirm(&mut self, account_id: U256)
 ```
-
-Confirms contract by transferring tokens from an escrow account
-to a seller and changing contract state to `Completed`.
+Confirms an escrow account by transferring tokens from it
+to a seller and changing an account state to `Closed`.
 
 Requirements:
-* `msg::source()` must be a buyer saved in contract.
-* Contract must be paid and uncompleted.
+* `msg::source()` must be a buyer saved in the account.
+* An account must be paid and unclosed.
 
 Arguments:
-* `contract_id`: a contract ID.
+* `account_id`: an account ID.
 
 ```rust
-async fn refund(&mut self, contract_id: u128)
+async fn refund(&mut self, account_id: U256)
 ```
-
 Refunds tokens from an escrow account to a buyer
-and changes contract state to `AwaitingDeposit`
-(that is, a contract can be reused).
+and changes an account state back to `AwaitingDeposit`
+(that is, the account can be reused).
 
 Requirements:
-* `msg::source()` must be a seller saved in contract.
-* Contract must be paid and uncompleted.
+* `msg::source()` must be a seller saved in the account.
+* An account must be paid and unclosed.
 
 Arguments:
-* `contract_id`: a contract ID.
+* `account_id`: an account ID.
 
 ```rust
-async fn cancel(&mut self, contract_id: u128)
+async fn cancel(&mut self, account_id: U256)
 ```
-
-Cancels (early completes) a contract by changing its state to `Completed`.
+Cancels (early closes) an escrow account by changing its state to `Closed`.
 
 Requirements:
-* `msg::source()` must be a buyer or seller saved in contract.
-* Contract must not be paid or completed.
+* `msg::source()` must be a buyer or seller saved in the account.
+* An account must not be paid or closed.
 
 Arguments:
-* `contract_id`: a contract ID.
+* `account_id`: an account ID.
+
+### Meta state
+It is also possible to provide a smart contract the ability to report about its state without consuming gas. This can be done by using the `meta_state` function. It gets the `EscrowState` enum and replies with the `EscrowStateReply` enum specified below:
+```rust
+enum EscrowState {
+    GetInfo(U256),
+}
+```
+
+```rust
+enum EscrowStateReply {
+    Info(Account),
+}
+```
 
 ### Actions & events
 **Action** is an enum that is sent to a program and contains info about what it should do. After a successful processing of **Action**, a program replies with **Event** enum that contains info about a processed **Action** and its result.
 
 ```rust
-pub enum EscrowAction {
+enum EscrowAction {
     Create {
         buyer: ActorId,
         seller: ActorId,
         amount: u128,
     },
-    Deposit {
-        contract_id: u128,
-    },
-    Confirm {
-        contract_id: u128,
-    },
-    Refund {
-        contract_id: u128,
-    },
-    Cancel {
-        contract_id: u128,
-    },
+    Deposit(U256),
+    Confirm(U256),
+    Refund(U256),
+    Cancel(U256),
 }
 ```
 
 ```rust
-pub enum EscrowEvent {
+enum EscrowEvent {
     Cancelled {
         buyer: ActorId,
         seller: ActorId,
@@ -150,17 +159,7 @@ pub enum EscrowEvent {
         buyer: ActorId,
         amount: u128,
     },
-    Created {
-        contract_id: u128,
-    },
-}
-```
-
-### Initialization config
-```rust
-pub struct InitEscrow {
-    // Address of a fungible token program.
-    pub ft_program_id: ActorId,
+    Created(U256),
 }
 ```
 


### PR DESCRIPTION
Updates the section of the escrow smart contract example according to https://github.com/gear-tech/apps/pull/50.