### PR TITLE
Advise the SS58 converter

### DIFF
--- a/docs/idea/account/ss58.md
+++ b/docs/idea/account/ss58.md
@@ -18,3 +18,6 @@ If you already have a Polkadot account, Kusama account, or any other Substrate-b
 2. In the opened window click on the dropdown menu "Display address format for" and select "Substrate":
 
 ![img alt](./img/address-format.png)
+
+# SS58 Address converter
+Unfortunately, addresses in the SS58 format are inconvenient for working with smart contracts in Gear IDEA, because they accept addresses as a 256-bit public key (also known as an actor ID). You can convert an address to a key by yourself or use this simple online converter: https://ss58.org (don't forget to select the **Address ⮊ Key** tab).


### PR DESCRIPTION
Updated sections:
- SS58 Address Format
Adds info about the input address format in Gear IDEA and suggest the converter (https://ss58.org) from an address in the SS58 format to a 256-bit public key.