### PR TITLE
Replace BTreeMap, BTreeSet to HashMap, HashSet and Vec in examples

### DIFF
--- a/docs/examples/DAO.md
+++ b/docs/examples/DAO.md
@@ -205,7 +205,6 @@ async fn submit_vote(
 ```rust
 async fn ragequit(
     &mut self,
-    transaction_id: Option<u64>,
     amount: u128,
     )
 ```

--- a/docs/examples/DAO.md
+++ b/docs/examples/DAO.md
@@ -77,19 +77,27 @@ let balance_response: FTEvent = msg::send_and_wait_for_reply(
 2. `lib.rs` - defines the contract logic.
 
 ### Structs
+To use the hashmap you should add the `hashbrown` package into your Cargo.toml file:
+```toml
+[dependecies]
+# ...
+hashbrown = "0.13.1"
+```
 
 The contract has the following structs:
 
 ```rust
+use hashbrown::HashMap;
+
 struct Dao {
     approved_token_program_id: ActorId,
     period_duration: u64,
     voting_period_length: u64,
     grace_period_length: u64,
     total_shares: u128,
-    members: BTreeMap<ActorId, Member>,
+    members: HashMap<ActorId, Member>,
     proposal_id: u128,
-    proposals: BTreeMap<u128, Proposal>,
+    proposals: HashMap<u128, Proposal>,
     locked_funds: u128,
 }
 ```
@@ -197,7 +205,8 @@ async fn submit_vote(
 ```rust
 async fn ragequit(
     &mut self,
-        amount: u128,
+    transaction_id: Option<u64>,
+    amount: u128,
     )
 ```
 

--- a/docs/examples/crowdsale.md
+++ b/docs/examples/crowdsale.md
@@ -41,7 +41,8 @@ let _transfer_response = msg::send_for_reply_as::<ft_main_io::FTokenAction, FTok
     0,
 )
 .expect("Error in sending a message `FTokenAction::Message`")
-.await;
+.await
+.expect("Error int transfer");
 ```
 
 2. `asserts.rs` - contains asserts functions: `owner_message` and `not_zero_address`. 

--- a/docs/examples/crowdsale.md
+++ b/docs/examples/crowdsale.md
@@ -18,6 +18,7 @@ Initial funds with which a token is purchased are determined by the Gear fungibl
 1. `messages.rs` - contains function of the fungible token contract. Crowdsale contract interacts with fungible token contract through transfer_tokens function:
 ```rust
 pub async fn transfer_tokens(
+    transaction_id: u64, // - associated transaction id
     token_id: &ActorId, // - the fungible token contract address
     from: &ActorId, // - the sender address
     to: &ActorId, // - the recipient address
@@ -26,18 +27,21 @@ pub async fn transfer_tokens(
 ```
 This function sends a message (the action is defined in the enum IcoAction) and gets a reply (the reply is defined in the enum IcoEvent):
 ```rust
-let _transfer_response = msg::send_for_reply(
-    *token_id,
-    FTAction::Transfer {
-        from: *from,
-        to: *to,
-        amount,
+let _transfer_response = msg::send_for_reply_as::<ft_main_io::FTokenAction, FTokenEvent>(
+    *token_address,
+    FTokenAction::Message {
+        transaction_id,
+        payload: ft_logic_io::Action::Transfer {
+            sender: *from,
+            recipient: *to,
+            amount: amount_tokens,
+        }
+        .encode(),
     },
     0,
 )
-.expect("Error in message")
-.await
-.expect("Error in transfer");
+.expect("Error in sending a message `FTokenAction::Message`")
+.await;
 ```
 
 2. `asserts.rs` - contains asserts functions: `owner_message` and `not_zero_address`. 
@@ -61,8 +65,16 @@ pub fn not_zero_address(address: &ActorId, message: &str) {
 3. `lib.rs` - defines the contract logic.
 
 ### Structs
+To use the hashmap you should add the `hashbrown` package into your Cargo.toml file:
+```toml
+[dependecies]
+# ...
+hashbrown = "0.13.1"
+```
 The contract has the following structs:
 ```rust
+use hashbrown::HashMap;
+
 struct IcoContract {
     ico_state: IcoState,
     start_price: u128,
@@ -72,7 +84,9 @@ struct IcoContract {
     tokens_goal: u128,
     owner: ActorId,
     token_address: ActorId,
-    token_holders: BTreeMap<ActorId, u128>,
+    token_holders: HashMap<ActorId, u128>,
+    transaction_id: u64,
+    transactions: HashMap<ActorId, u64>,
 }
 ```
 where:
@@ -102,6 +116,7 @@ async fn start_ico(&mut self, config: IcoAction)
 replies with:
 ```rust
 IcoEvent::SaleStarted {
+    transaction_id,
     duration,
     start_price,
     tokens_goal,

--- a/docs/examples/game-of-chance.md
+++ b/docs/examples/game-of-chance.md
@@ -127,7 +127,7 @@ pub struct GOCState {
     /// See the documentation of [`GOCEvent::Started`].
     pub ending: u64,
     /// Participants of the current game round.
-    pub players: BTreeSet<ActorId>,
+    pub players: Vec<ActorId>,
     /// The current game round prize fund.
     ///
     /// It's calculated by multiplying `participation_cost` and the number

--- a/docs/examples/gmt-1155.md
+++ b/docs/examples/gmt-1155.md
@@ -28,21 +28,24 @@ To use the default implementation you should include the packages into your Carg
 ```toml
 gear-contract-libraries = { path = "https://github.com/gear-dapps/gear-lib" }
 derive_traits = { path = "https://github.com/gear-dapps/gear-lib/tree/master/derive" }
+hashbrown = "0.13.1"
 ```
 
 The states that multitoken contract store are defined in the struct MTKState:
 
 ```rust
+use hashbrown::HashMap;
+
 #[derive(Debug, Default)]
 pub struct MTKState {
     pub name: String,
     pub symbol: String,
     pub base_uri: String,
-    pub balances: BTreeMap<TokenId, BTreeMap<ActorId, u128>>,
-    pub approvals: BTreeMap<ActorId, BTreeMap<ActorId, bool>>,
-    pub token_metadata: BTreeMap<TokenId, TokenMetadata>,
+    pub balances: HashMap<TokenId, HashMap<ActorId, u128>>,
+    pub approvals: HashMap<ActorId, HashMap<ActorId, bool>>,
+    pub token_metadata: HashMap<TokenId, TokenMetadata>,
     // owner for nft
-    pub owners: BTreeMap<TokenId, ActorId>,
+    pub owners: HashMap<TokenId, ActorId>,
 }
 ```
 
@@ -51,7 +54,7 @@ To reuse the default struct you need derive the MTKTokenState trait and mark the
 ```rust
 use derive_traits::{MTKCore, MTKTokenState, StateKeeper};
 use gear_contract_libraries::multitoken::{io::*, mtk_core::*, state::*};
-
+use hashbrown::HashMap;
 
 #[derive(Debug, Default, MTKTokenState, MTKCore, StateKeeper)]
 pub struct SimpleMTK {
@@ -59,7 +62,7 @@ pub struct SimpleMTK {
     pub tokens: MTKState,
     pub token_id: TokenId,
     pub owner: ActorId,
-    pub supply: BTreeMap<TokenId, u128>,
+    pub supply: HashMap<TokenId, u128>,
 }
 ```
 
@@ -132,7 +135,7 @@ pub struct SimpleMTK {
     pub tokens: MTKState,
     pub token_id: TokenId,
     pub owner: ActorId,
-    pub supply: BTreeMap<TokenId, u128>,
+    pub supply: HashMap<TokenId, u128>,
 }
 
 static mut CONTRACT: Option<SimpleMTK> = None;

--- a/docs/examples/gnft-4907.md
+++ b/docs/examples/gnft-4907.md
@@ -25,15 +25,18 @@ To use the default implementation you should include the packages into your *Car
 ```toml
 gear-lib = { git = "https://github.com/gear-dapps/gear-lib.git" }
 gear-lib-derive = { git = "https://github.com/gear-dapps/gear-lib.git" }
+hashbrown = "0.13.1"
 ```
 
 Rentable NFT contains regular NFT (gnft-721) and additional field  `users_info`:
 
 ```rust
+use hashbrown::HashMap;
+
 #[derive(Debug, Default)]
 pub struct RentableNFT {
     pub nft: NFT,
-    pub users_info: BTreeMap<TokenId, UserInfo>,
+    pub users_info: HashMap<TokenId, UserInfo>,
 }
 ```
 In all other cases, everything also corresponds to the usual [non-fungible-token](./gnft-721) contract.

--- a/docs/examples/gnft-721.md
+++ b/docs/examples/gnft-721.md
@@ -28,20 +28,23 @@ To use the default implementation you should include the packages into your *Car
 ```toml
 gear-lib = { git = "https://github.com/gear-dapps/gear-lib.git" }
 gear-lib-derive = { git = "https://github.com/gear-dapps/gear-lib.git" }
+hashbrown = "0.13.1"
 ```
 
 The states that non-fungible-contract store are defined in the struct `NFTState`:
 
 ```rust
+use hashbrown::HashMap;
+
 #[derive(Debug, Default)]
 pub struct NFTState {
     pub name: String,
     pub symbol: String,
     pub base_uri: String,
-    pub owner_by_id: BTreeMap<TokenId, ActorId>,
-    pub token_approvals: BTreeMap<TokenId, Vec<ActorId>>,
-    pub token_metadata_by_id: BTreeMap<TokenId, Option<TokenMetadata>>,
-    pub tokens_for_owner: BTreeMap<ActorId, Vec<TokenId>>,
+    pub owner_by_id: HashMap<TokenId, ActorId>,
+    pub token_approvals: HashMap<TokenId, Vec<ActorId>>,
+    pub token_metadata_by_id: HashMap<TokenId, Option<TokenMetadata>>,
+    pub tokens_for_owner: HashMap<ActorId, Vec<TokenId>>,
     pub royalties: Option<Royalties>,
 }
 ```
@@ -58,6 +61,7 @@ pub struct NFT {
     pub token: NFTState,
     pub token_id: TokenId,
     pub owner: ActorId,
+    pub transactions: HashMap<H256, NFTEvent>,
 }
 ```
 
@@ -102,6 +106,7 @@ pub struct NFT {
     pub token: NFTState,
     pub token_id: TokenId,
     pub owner: ActorId,
+    pub transactions: HashMap<H256, NFTEvent>,
 }
 
 static mut CONTRACT: Option<NFT> = None;

--- a/docs/examples/nft-marketplace/marketplace.md
+++ b/docs/examples/nft-marketplace/marketplace.md
@@ -19,17 +19,25 @@ Gear also [provides](https://github.com/gear-tech/gear-js/tree/master/apps/marke
 
 <!-- You can watch a video on how to get the NFT Marketplace application up and running and its capabilities here: **https://youtu.be/4suveOT3O-Y**.
 -->
+To use the hashmap you should include `hashbrown` package into your *Cargo.toml* file:
+```toml
+[dependecies]
+# ...
+hashbrown = "0.13.1"
+```
 
 ## Logic
 The contract state:
 ```rust
+use hashbrown::{HashMap, HashSet};
+
 pub struct Market {
     pub admin_id: ActorId,
     pub treasury_id: ActorId,
     pub treasury_fee: u128,
-    pub items: BTreeMap<ContractAndTokenId, Item>,
-    pub approved_nft_contracts: BTreeSet<ActorId>,
-    pub approved_ft_contracts: BTreeSet<ActorId>,
+    pub items: HashMap<ContractAndTokenId, Item>,
+    pub approved_nft_contracts: HashSet<ActorId>,
+    pub approved_ft_contracts: HashSet<ActorId>,
 }
 ```
 - `admin_id` - an account who has the right to approve non-fungible-token and fungible-tokens contracts that can be used in the marketplace contract;

--- a/docs/examples/onchain-nft.md
+++ b/docs/examples/onchain-nft.md
@@ -32,11 +32,14 @@ To use the default implementation you should include the packages into your *Car
 ```toml
 gear-lib = { git = "https://github.com/gear-dapps/gear-lib.git" }
 gear-lib-derive = { git = "https://github.com/gear-dapps/gear-lib.git" }
+hashbrown = "0.13.1"
 ```
 
 First, we start by modifying the state and the init message:
 
 ```rust
+use hashbrown::{HashMap, HashSet};
+
 #[derive(Debug, Default, NFTStateKeeper, NFTCore, NFTMetaState)]
 pub struct OnChainNFT {
     #[NFTStateField]
@@ -44,9 +47,9 @@ pub struct OnChainNFT {
     pub token_id: TokenId,
     pub owner: ActorId,
     pub base_image: String,
-    pub layers: BTreeMap<LayerId, Vec<String>>,
-    pub nfts: BTreeMap<TokenId, Vec<ItemId>>,
-    pub nfts_existence: BTreeSet<String>,
+    pub layers: HashMap<LayerId, Vec<String>>,
+    pub nfts: HashMap<TokenId, Vec<ItemId>>,
+    pub nfts_existence: HashSet<String>,
 }
 ```
 
@@ -57,7 +60,7 @@ pub struct InitOnChainNFT {
     pub symbol: String,
     pub base_uri: String,
     pub base_image: String,
-    pub layers: BTreeMap<LayerId, Vec<String>>,
+    pub layers: Vec<(LayerId, Vec<String>)>,
     pub royalties: Option<Royalties>,
 }
 ```

--- a/docs/examples/staking.md
+++ b/docs/examples/staking.md
@@ -84,6 +84,12 @@ Admin can view the Stakers list (`GetStakers` message). The admin can update the
 The user first makes a bet (`Stake` message), and then he can receive his reward on demand (`GetReward` message). The user can withdraw part of the amount (`Withdraw` message).
 
 ## Interface
+To use the hashmap you should include `hashbrown` package into your *Cargo.toml* file:
+```toml
+[dependecies]
+# ...
+hashbrown = "0.13.1"
+```
 ### Source files
 1. `staking/src/lib.rs` - contains functions of the 'staking' contract.
 2. `staking/io/src/lib.rs` - contains Enums and structs that the contract receives and sends in the reply.
@@ -93,6 +99,8 @@ The user first makes a bet (`Stake` message), and then he can receive his reward
 The contract has the following structs:
 
 ```rust
+use hashbrown::HashMap;
+
 struct Staking {
     owner: ActorId,
     staking_token_address: ActorId,
@@ -104,7 +112,7 @@ struct Staking {
     reward_total: u128,
     all_produced: u128,
     reward_produced: u128,
-    stakers: BTreeMap<ActorId, Staker>,
+    stakers: HashMap<ActorId, Staker>,
 }
 ```
 where:
@@ -193,7 +201,7 @@ pub enum StakingState {
 }
 
 pub enum StakingStateReply {
-    Stakers(BTreeMap<ActorId, Staker>),
+    Stakers(Vec<(ActorId, Staker)>),
     Staker(Staker),
 }
 ```

--- a/docs/examples/supply-chain.md
+++ b/docs/examples/supply-chain.md
@@ -74,13 +74,13 @@ pub enum ItemState {
 pub struct InitSupplyChain {
     /// Addresses that'll have the right to interact with a supply chain on
     /// behalf of a producer.
-    pub producers: BTreeSet<ActorId>,
+    pub producers: Vec<ActorId>,
     /// Addresses that'll have the right to interact with a supply chain on
     /// behalf of a distributor.
-    pub distributors: BTreeSet<ActorId>,
+    pub distributors: Vec<ActorId>,
     /// Addresses that'll have the right to interact with a supply chain on
     /// behalf of a retailer.
-    pub retailers: BTreeSet<ActorId>,
+    pub retailers: Vec<ActorId>,
 
     /// A FT program address.
     pub ft_program: ActorId,

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/examples/DAO.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/examples/DAO.md
@@ -67,18 +67,27 @@ let balance_response: FTEvent = msg::send_and_wait_for_reply(
 
 ## 合约结构
 
+`Cargo.toml`
+```toml
+[dependecies]
+# ...
+hashbrown = "0.13.1"
+```
+
 合约包含了以下结构：
 
 ```rust
+use hashbrown::HashMap;
+
 struct Dao {
     approved_token_program_id: ActorId,
     period_duration: u64,
     voting_period_length: u64,
     grace_period_length: u64,
     total_shares: u128,
-    members: BTreeMap<ActorId, Member>,
+    members: HashMap<ActorId, Member>,
     proposal_id: u128,
-    proposals: BTreeMap<u128, Proposal>,
+    proposals: HashMap<u128, Proposal>,
     locked_funds: u128,
 }
 ```

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/examples/gmt-1155.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/examples/gmt-1155.md
@@ -34,21 +34,24 @@ gMT 合约的实现为 [gear-lib/multitoken](https://github.com/gear-dapps/gear-
 ```toml
 gear-contract-libraries = { path = "https://github.com/gear-dapps/gear-lib" }
 derive_traits = { path = "https://github.com/gear-dapps/gear-lib/tree/master/derive" }
+hashbrown = "0.13.1"
 ```
 
 multitoken 合约的存储状态在结构 `MTKState` 中定义：
 
 ```rust
+use hashbrown::HashMap;
+
 #[derive(Debug, Default)]
 pub struct MTKState {
     pub name: String,
     pub symbol: String,
     pub base_uri: String,
-    pub balances: BTreeMap<TokenId, BTreeMap<ActorId, u128>>,
-    pub approvals: BTreeMap<ActorId, BTreeMap<ActorId, bool>>,
-    pub token_metadata: BTreeMap<TokenId, TokenMetadata>,
+    pub balances: HashMap<TokenId, HashMap<ActorId, u128>>,
+    pub approvals: HashMap<ActorId, HashMap<ActorId, bool>>,
+    pub token_metadata: HashMap<TokenId, TokenMetadata>,
     // owner for nft
-    pub owners: BTreeMap<TokenId, ActorId>,
+    pub owners: HashMap<TokenId, ActorId>,
 }
 ```
 
@@ -59,6 +62,7 @@ pub struct MTKState {
 ```rust
 use derive_traits::{MTKCore, MTKTokenState, StateKeeper};
 use gear_contract_libraries::multitoken::{io::*, mtk_core::*, state::*};
+use hashbrown::HashMap;
 
 #[derive(Debug, Default, MTKTokenState, MTKCore, StateKeeper)]
 pub struct SimpleMTK {
@@ -66,7 +70,7 @@ pub struct SimpleMTK {
     pub tokens: MTKState,
     pub token_id: TokenId,
     pub owner: ActorId,
-    pub supply: BTreeMap<TokenId, u128>,
+    pub supply: HashMap<TokenId, u128>,
 }
 ```
 
@@ -139,7 +143,7 @@ pub struct SimpleMTK {
     pub tokens: MTKState,
     pub token_id: TokenId,
     pub owner: ActorId,
-    pub supply: BTreeMap<TokenId, u128>,
+    pub supply: HashMap<TokenId, u128>,
 }
 
 static mut CONTRACT: Option<SimpleMTK> = None;

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/examples/gnft-721.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/examples/gnft-721.md
@@ -30,20 +30,23 @@ NFT 合约的实现为[gear-contract-libraries/non_fungible_token](https://githu
 ```toml
 gear-lib = { git = "https://github.com/gear-dapps/gear-lib.git" }
 gear-lib-derive = { git = "https://github.com/gear-dapps/gear-lib.git" }
+hashbrown = "0.13.1"
 ```
 
 non-fungible 合约的存储状态在结构 `NFTState` 中定义：
 
 ```rust
+use hashbrown::HashMap;
+
 #[derive(Debug, Default)]
 pub struct NFTState {
     pub name: String,
     pub symbol: String,
     pub base_uri: String,
-    pub owner_by_id: BTreeMap<TokenId, ActorId>,
-    pub token_approvals: BTreeMap<TokenId, Vec<ActorId>>,
-    pub token_metadata_by_id: BTreeMap<TokenId, Option<TokenMetadata>>,
-    pub tokens_for_owner: BTreeMap<ActorId, Vec<TokenId>>,
+    pub owner_by_id: HashMap<TokenId, ActorId>,
+    pub token_approvals: HashMap<TokenId, Vec<ActorId>>,
+    pub token_metadata_by_id: HashMap<TokenId, Option<TokenMetadata>>,
+    pub tokens_for_owner: HashMap<ActorId, Vec<TokenId>>,
     pub royalties: Option<Royalties>,
 }
 ```
@@ -60,6 +63,7 @@ pub struct NFT {
     pub token: NFTState,
     pub token_id: TokenId,
     pub owner: ActorId,
+    pub transactions: HashMap<H256, NFTEvent>,
 }
 ```
 
@@ -103,6 +107,7 @@ pub struct NFT {
     pub token: NFTState,
     pub token_id: TokenId,
     pub owner: ActorId,
+    pub transactions: HashMap<H256, NFTEvent>,
 }
 
 static mut CONTRACT: Option<NFT> = None;

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/examples/onchain-nft.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/examples/onchain-nft.md
@@ -37,11 +37,14 @@ NFT 合约的默认实现是在 Gear 库中提供的：[gear-lib/non_fungible_to
 ```toml
 gear-lib = { git = "https://github.com/gear-dapps/gear-lib.git" }
 gear-lib-derive = { git = "https://github.com/gear-dapps/gear-lib.git" }
+hashbrown = "0.13.1"
 ```
 
 首先，我们从修改状态和 init 信息开始：
 
 ```rust
+use hashbrown::{HashMap, HashSet};
+
 #[derive(Debug, Default, NFTStateKeeper, NFTCore, NFTMetaState)]
 pub struct OnChainNFT {
     #[NFTStateField]
@@ -49,9 +52,9 @@ pub struct OnChainNFT {
     pub token_id: TokenId,
     pub owner: ActorId,
     pub base_image: String,
-    pub layers: BTreeMap<LayerId, Vec<String>>,
-    pub nfts: BTreeMap<TokenId, Vec<ItemId>>,
-    pub nfts_existence: BTreeSet<String>,
+    pub layers: HashMap<LayerId, Vec<String>>,
+    pub nfts: HashMap<TokenId, Vec<ItemId>>,
+    pub nfts_existence: HashSet<String>,
 }
 ```
 
@@ -62,7 +65,7 @@ pub struct InitOnChainNFT {
     pub symbol: String,
     pub base_uri: String,
     pub base_image: String,
-    pub layers: BTreeMap<LayerId, Vec<String>>,
+    pub layers: Vec<(LayerId, Vec<String>)>,
     pub royalties: Option<Royalties>,
 }
 ```

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/examples/staking.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/examples/staking.md
@@ -93,10 +93,17 @@ $$
 2. `staking/io/src/lib.rs` - 包含合约在回复中接收和发送的 Enums 和结构。
 
 ### 结构
-
+`Cargo.toml`
+```toml
+[dependecies]
+# ...
+hashbrown = "0.13.1"
+```
 该合约有以下结构：
 
 ```rust
+use hashbrown::HashMap;
+
 struct Staking {
     owner: ActorId,
     staking_token_address: ActorId,
@@ -108,7 +115,7 @@ struct Staking {
     reward_total: u128,
     all_produced: u128,
     reward_produced: u128,
-    stakers: BTreeMap<ActorId, Staker>,
+    stakers: HashMap<ActorId, Staker>,
 }
 ```
 
@@ -192,7 +199,7 @@ pub enum StakingState {
 }
 
 pub enum StakingStateReply {
-    Stakers(BTreeMap<ActorId, Staker>),
+    Stakers(Vec<(ActorId, Staker)>),
     Staker(Staker),
 }
 ```

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/examples/supply-chain.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/examples/supply-chain.md
@@ -53,9 +53,9 @@ enum ItemState {
 
 ```rust
 struct InitSupplyChain {
-    producers: BTreeSet<ActorId>,
-    distributors: BTreeSet<ActorId>,
-    retailers: BTreeSet<ActorId>,
+    producers: Vec<ActorId>,
+    distributors: Vec<ActorId>,
+    retailers: Vec<ActorId>,
 
     ft_program_id: ActorId,
     nft_program_id: ActorId,


### PR DESCRIPTION
Updated sections:
- docs/examples/DAO.md
- docs/examples/crowdsale.md
- docs/examples/game-of-chance.md
- docs/examples/gmt-1155.md
- docs/examples/gnft-4907.md
- docs/examples/gnft-721.md
- docs/examples/nft-marketplace/marketplace.md
- docs/examples/onchain-nft.md
- docs/examples/staking.md
- docs/examples/supply-chain.md
