### PR TITLE
`#[ignore]` tests with `gclient`

### DIFF
--- a/docs/developing-contracts/testing-gclient.mdx
+++ b/docs/developing-contracts/testing-gclient.mdx
@@ -203,7 +203,7 @@ Run the following command and wait for all tests to be green:
 cargo test --release -- --include-ignored
 ```
 
-It's recommended to mark with the `#[ignore]` attribute tests with `gclient` to separate their slow execution of the rest. To execute ignored tests with Cargo, add the `--include-ignored` flag after a double dash (`--`) as shown above.
+It's recommended to mark with the `#[ignore]` attribute tests with `gclient` to separate their slow execution from the rest. To execute ignored tests with Cargo, add the `--include-ignored` flag after a double dash (`--`) as shown above.
 
 Let's explore what we've done in the test function above.
 

--- a/docs/developing-contracts/testing-gclient.mdx
+++ b/docs/developing-contracts/testing-gclient.mdx
@@ -143,6 +143,7 @@ use gclient::{EventProcessor, GearApi, Result};
 const WASM_PATH: &str = "./target/wasm32-unknown-unknown/release/first_gear_app.opt.wasm";
 
 #[tokio::test]
+#[ignore]
 async fn test_example() -> Result<()> {
     // Create API instance
     let api = GearApi::dev().await?;
@@ -199,8 +200,10 @@ async fn test_example() -> Result<()> {
 Run the following command and wait for all tests to be green:
 
 ```shell
-cargo test --release
+cargo test --release -- --include-ignored
 ```
+
+It's recommended to mark with the `#[ignore]` attribute tests with `gclient` to separate their slow execution of the rest. To execute ignored tests, add the `--include-ignored` flag after a double dash (`--`) as shown above.
 
 Let's explore what we've done in the test function above.
 

--- a/docs/developing-contracts/testing-gclient.mdx
+++ b/docs/developing-contracts/testing-gclient.mdx
@@ -203,7 +203,7 @@ Run the following command and wait for all tests to be green:
 cargo test --release -- --include-ignored
 ```
 
-It's recommended to mark with the `#[ignore]` attribute tests with `gclient` to separate their slow execution of the rest. To execute ignored tests, add the `--include-ignored` flag after a double dash (`--`) as shown above.
+It's recommended to mark with the `#[ignore]` attribute tests with `gclient` to separate their slow execution of the rest. To execute ignored tests with Cargo, add the `--include-ignored` flag after a double dash (`--`) as shown above.
 
 Let's explore what we've done in the test function above.
 


### PR DESCRIPTION
Updates section:
- Developing Smart Contracts / Testing with `gclient`

Adds a recommendation on how to separate the slow execution of tests with `gclient` from the rest.