### PR TITLE
Changing useApi to useAccount in React-hooks

### DIFF
--- a/docs/api/tooling/react-hooks.md
+++ b/docs/api/tooling/react-hooks.md
@@ -66,7 +66,7 @@ const { api, isApiReady } = useApi();
 ```js
 import { useAccount } from '@gear-js/react-hooks';
 
-const { account, isAccountReady } = useApi();
+const { account, isAccountReady } = useAccount();
 ```
 
 ### useAlert


### PR DESCRIPTION
Updated sections:

-React-hooks
