### PR TITLE
fix(docs): correct spelling and fix mistakes

### DIFF
--- a/docs/api/calculate-gas.md
+++ b/docs/api/calculate-gas.md
@@ -5,7 +5,7 @@ sidebar_label: Calculate gas
 
 # Calculate gas
 
-Gear nodes charge gas fees for all network operations, whether that be executing a program’s code or processing a message. This gas is paid by the initiator of these actions.
+Gear nodes charge gas fees for all network operations, whether that be executing a program’s code or processing a message. This gas is paid for by the initiator of these actions.
 
 They guarantee successful message processing and to avoid errors like `Gaslimit exceeded`, you can simulate the execution in advance to calculate the exact amount of gas that will be consumed.
 
@@ -16,11 +16,11 @@ To find out the minimum gas amount required to send extrinsic, use `gearApi.prog
 :::info
 Gas calculation returns the GasInfo object, which contains 5 parameters:
 
-- `min_limit` - minimum gas limit required for execution
+- `min_limit` - minimum gas limit required for the execution
 - `reserved` - gas amount that will be reserved for other on-chain interactions
 - `burned` - number of gas burned during message processing
 - `may_be_returned` - value that can be returned in some cases
-- `waited` - notifies that the message will be added to waitlist
+- `waited` - notifies that the message will be added to the waitlist
   :::
 
 ### Init (for upload_program extrinsic)
@@ -32,8 +32,8 @@ const gas = await gearApi.program.calculateGas.initUpload(
   '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d', // source id
   code,
   '0x00', // payload
-  0, //value
-  true, // allow other panics
+  0,      // value
+  true,   // allow other panics
 );
 
 console.log(gas.toHuman());
@@ -48,29 +48,29 @@ const gas = await gearApi.program.calculateGas.initCreate(
   '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d', // source id
   codeId,
   '0x00', // payload
-  0, //value
-  true, // allow other panics
+  0,      // value
+  true,   // allow other panics
 );
-
 console.log(gas.toHuman());
 ```
 
 ### Handle
 
 ```javascript
+import { getProgramMetadata } from '@gear-js/api';
 const code = fs.readFileSync('demo_meta.opt.wasm');
 const meta = await getWasmMetadata(fs.readFileSync('demo_meta.opt.wasm'));
 const gas = await gearApi.program.calculateGas.handle(
   '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d', // source id
-  '0xa178362715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d', //program id
+  '0xa178362715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d', // program id
   {
     id: {
       decimal: 64,
       hex: '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d',
     },
-  }, // payload
-  0, // value
-  false, // allow other panics
+  },      // payload
+  0,      // value
+  false,  // allow other panics
   meta,
 );
 console.log(gas.toHuman());
@@ -84,10 +84,10 @@ const meta = await getWasmMetadata(fs.readFileSync('demo_async.opt.wasm'));
 const gas = await gearApi.program.calculateGas.reply(
   '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d', // source id
   '0x518e6bc03d274aadb3454f566f634bc2b6aef9ae6faeb832c18ae8300fd72635', // message id
-  0, // exit code
+  0,      // exit code
   'PONG', // payload
-  0, // value
-  true, // allow other panics
+  0,      // value
+  true,   // allow other panics
   meta,
 );
 console.log(gas.toHuman());

--- a/docs/api/calculate-gas.md
+++ b/docs/api/calculate-gas.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-sidebar_label: Calculate gas
+sidebar_label: Calculate Gas
 ---
 
 # Calculate gas
@@ -42,7 +42,7 @@ console.log(gas.toHuman());
 ### Init (for create_program extrinsic)
 
 ```javascript
-const codeId = '0x...';
+const codeId = '0x…';
 
 const gas = await gearApi.program.calculateGas.initCreate(
   '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d', // source id
@@ -58,7 +58,7 @@ console.log(gas.toHuman());
 
 ```javascript
 import { getProgramMetadata } from '@gear-js/api';
-const meta = await getProgramMetadata('0x' + fs.readFileSync('demo_new_meta.meta.txt'));
+const metadata = await getProgramMetadata('0x' + fs.readFileSync('demo_new_meta.meta.txt'));
 const gas = await gearApi.program.calculateGas.handle(
   '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d', // source id
   '0xa178362715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d', // program id
@@ -70,7 +70,7 @@ const gas = await gearApi.program.calculateGas.handle(
   },      // payload
   0,      // value
   false,  // allow other panics
-  meta,
+  metadata,
 );
 console.log(gas.toHuman());
 ```
@@ -79,7 +79,7 @@ console.log(gas.toHuman());
 
 ```javascript
 import { getProgramMetadata } from '@gear-js/api';
-const meta = await getProgramMetadata('0x' + fs.readFileSync('demo_async.meta.txt'));
+const metadata = await getProgramMetadata('0x' + fs.readFileSync('demo_async.meta.txt'));
 const gas = await gearApi.program.calculateGas.reply(
   '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d', // source id
   '0x518e6bc03d274aadb3454f566f634bc2b6aef9ae6faeb832c18ae8300fd72635', // message id
@@ -87,7 +87,7 @@ const gas = await gearApi.program.calculateGas.reply(
   'PONG', // payload
   0,      // value
   true,   // allow other panics
-  meta,
+  metadata,
 );
 console.log(gas.toHuman());
 ```

--- a/docs/api/calculate-gas.md
+++ b/docs/api/calculate-gas.md
@@ -58,8 +58,7 @@ console.log(gas.toHuman());
 
 ```javascript
 import { getProgramMetadata } from '@gear-js/api';
-const code = fs.readFileSync('demo_meta.opt.wasm');
-const meta = await getWasmMetadata(fs.readFileSync('demo_meta.opt.wasm'));
+const meta = await getProgramMetadata('0x' + fs.readFileSync('demo_new_meta.meta.txt'));
 const gas = await gearApi.program.calculateGas.handle(
   '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d', // source id
   '0xa178362715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d', // program id
@@ -79,8 +78,8 @@ console.log(gas.toHuman());
 ### Reply to a message
 
 ```javascript
-const code = fs.readFileSync('demo_async.opt.wasm');
-const meta = await getWasmMetadata(fs.readFileSync('demo_async.opt.wasm'));
+import { getProgramMetadata } from '@gear-js/api';
+const meta = await getProgramMetadata('0x' + fs.readFileSync('demo_async.meta.txt'));
 const gas = await gearApi.program.calculateGas.reply(
   '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d', // source id
   '0x518e6bc03d274aadb3454f566f634bc2b6aef9ae6faeb832c18ae8300fd72635', // message id

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -24,7 +24,6 @@ unsub();
 **Summary:** When a user successfully sends a message to a program and it gets added to the Gear message queue.
 
 ```rust
-
 MessageQueued {
     /// Generated id of the message.
     id: MessageId,
@@ -60,7 +59,7 @@ UserMessageSent {
 }
 ```
 
-### UserMessageSent
+### UserMessageRead
 
 **Summary:** When a message has been marked as "read" and it has been removed from the `Mailbox`. This event only affects messages, which were already prior inserted into the `Mailbox`.
 
@@ -193,10 +192,10 @@ const unsub = gearApi.gearEvents.subscribeToGearEvent(
     },
   }) => {
     console.log(`
-  messageId: ${id.toHex()}
-  source: ${source.toHex()}
-  payload: ${payload.toHuman()}
-  `);
+      messageId: ${id.toHex()}
+      source: ${source.toHex()}
+      payload: ${payload.toHuman()}
+    `);
   },
 );
 // Unsubscribe
@@ -231,10 +230,10 @@ unsub();
 const unsub = await gearApi.gearEvents.subscribeToTransferEvents(
   ({ data: { from, to, amount } }) => {
     console.log(`
-    Transfer balance:
-    from: ${from.toHex()}
-    to: ${to.toHex()}
-    amount: ${+amount.toString()}
+      Transfer balance:
+      from: ${from.toHex()}
+      to: ${to.toHex()}
+      amount: ${+amount.toString()}
     `);
   },
 );

--- a/docs/api/events.mdx
+++ b/docs/api/events.mdx
@@ -185,7 +185,7 @@ gearApi.query.system.events((events) => {
 ### Subscribe to messages sent from a program
 
 ```javascript
-const unsub = api.gearEvents.subscribeToGearEvent(
+const unsub = gearApi.gearEvents.subscribeToGearEvent(
   'UserMessageSent',
   ({
     data: {
@@ -206,7 +206,7 @@ unsub();
 ### Subscribe to messages intended for a program
 
 ```javascript
-const unsub = api.gearEvents.subscribeToGearEvent(
+const unsub = gearApi.gearEvents.subscribeToGearEvent(
   'MessageQueued',
   ({ data: { id, source, destination, entry } }) => {
     console.log({

--- a/docs/api/extra-queries.md
+++ b/docs/api/extra-queries.md
@@ -56,10 +56,10 @@ extrinsics.forEach((extrinsic) => {
 ## Get transaction fee
 
 ```javascript
-const api = await GearApi.create();
-api.program.submit({ code, gasLimit });
-// same for api.message, api.reply and others
-const paymentInfo = await api.program.paymentInfo(alice);
+const gearApi = await GearApi.create();
+gearApi.program.submit({ code, gasLimit });
+// same for gearApi.message, gearApi.reply and others
+const paymentInfo = await gearApi.program.paymentInfo(alice);
 const transactionFee = paymentInfo.partialFee.toNumber();
 consolg.log(transactionFee);
 ```

--- a/docs/api/getting-started.mdx
+++ b/docs/api/getting-started.mdx
@@ -39,7 +39,7 @@ You can also connect to a different node:
 
 ```javascript
 const gearApi = await GearApi.create({
-  providerAddress: 'wss://someIP:somePort',
+  providerAddress: 'ws[s]://someIP[:somePort]',
 });
 ```
 
@@ -53,10 +53,10 @@ For connection to local node use:
 ws://127.0.0.1:9944
 ```
 
-For connection to Testnet use:
+For connection to Vara Testnet use:
 
 ```bash
-wss://rpc-node.gear-tech.io
+wss://testnet.vara.rs
 ```
 
 :::
@@ -77,7 +77,9 @@ This simple example describes how to subscribe to a new blocks and get chain spe
 
 ```js
 async function connect() {
-  const gearApi = await GearApi.create();
+  const gearApi = await GearApi.create({
+    providerAddress: 'wss://testnet.vara.rs',
+  });
 
   const [chain, nodeName, nodeVersion] = await Promise.all([
     gearApi.chain(),
@@ -95,6 +97,7 @@ async function connect() {
     );
   });
 }
+
 connect().catch(console.error);
 ```
 

--- a/docs/api/getting-started.mdx
+++ b/docs/api/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 1
-sidebar_label: Getting started
+sidebar_label: Getting Started
 ---
 
 # Getting started

--- a/docs/api/mailbox.md
+++ b/docs/api/mailbox.md
@@ -10,8 +10,8 @@ The mailbox contains messages from the program that are waiting for user action.
 ## Read messages from Mailbox
 
 ```javascript
-const api = await GearApi.create();
-const mailbox = await api.mailbox.read(
+const gearApi = await GearApi.create();
+const mailbox = await gearApi.mailbox.read(
   '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
 );
 console.log(mailbox);
@@ -19,21 +19,21 @@ console.log(mailbox);
 
 ## Claim value
 
-To claim value from a message in the mailbox use `api.mailbox.claimValue.submit` method.
+To claim value from a message in the mailbox use `GearApi.mailbox.claimValue.submit` method.
 
 ```javascript
-const api = await GearApi.create();
-const submitted = await api.mailbox.claimValue.submit(messageId);
-await api.mailbox.claimValue.signAndSend(...);
+const gearApi = await GearApi.create();
+const submitted = await gearApi.mailbox.claimValue.submit(messageId);
+await gearApi.mailbox.claimValue.signAndSend(/* ... */);
 ```
 
 ## Waitlist
 
-To read the program's waitlist use `api.waitlist.read` method.
+To read the program's waitlist use `GearApi.waitlist.read` method.
 
 ```javascript
 const gearApi = await GearApi.create();
-const programId = '0x1234...';
-const waitlist = await api.waitlist.read(programId);
+const programId = '0x1234…';
+const waitlist = await gearApi.waitlist.read(programId);
 console.log(waitlist);
 ```

--- a/docs/api/metadata-type-creation.md
+++ b/docs/api/metadata-type-creation.md
@@ -18,9 +18,9 @@ To get program metadata, use the `getProgramMetadata` function:
 ```javascript
 import { getProgramMetadata } from '@gear-js/api';
 
-const metadata = getProgramMetadata(`0x...`);
+const metadata = getProgramMetadata('0x…');
 
-// The function getProgramMetadata() takes the program's metadata in the format of a hex string. 
+// The function getProgramMetadata() takes the program's metadata in the format of a hex string.
 // It returns an object of the `ProgramMetadata` class with the property `types` containing all program types.
 
 metadata.types.init.input; // can be used to encode input message for init entrypoint of the program
@@ -52,7 +52,7 @@ Both `ProgramMetadata` and `StateMetadata` classes have a few methods that can h
 ```js
 import { ProgramMetadata } from '@gear-js/api`;
 
-const metadata = getProgramMetadata(`0x...`);
+const metadata = getProgramMetadata('0x…');
 
 // returns the name of the type with this index
 metadata.getTypeName(4);
@@ -61,7 +61,7 @@ metadata.getTypeName(4);
 metadata.getTypeDef(4);
 
 // if you need to get a type structure with an additional field (name, type, kind, len) you have to pass the second argument
-metadata.getTypeDef(4, true); 
+metadata.getTypeDef(4, true);
 
 // returns all custom types that existed in the registry of the program
 metadata.getAllTypes();
@@ -79,7 +79,8 @@ If for some reason you need to create a type "manually" to encode/decode any pay
 ```javascript
 import { CreateType } from '@gear-js/api';
 
-// If "TypeName" already registered. Lear more https://polkadot.js.org/docs/api/start/types.create#choosing-how-to-create
+// If "TypeName" already registered.
+// Learn more https://polkadot.js.org/docs/api/start/types.create#choosing-how-to-create
 const result = CreateType.create('TypeName', somePayload);
 
 // Otherwise need to add metadata containing TypeName and all required types
@@ -88,9 +89,9 @@ const result = CreateType.create('TypeName', somePayload, metadata);
 The result of this function is data of type `Codec` and it has the following methods:
 
 ```javascript
-result.toHex(); // - returns a hex represetation of the value
-result.toHuman(); // - returns human-friendly object representation of the value
-result.toString(); //  - returns a string representation of the value
-result.toU8a(); // - encodes the value as a Unit8Array
-result.toJSON(); // - converts the value to JSON
+result.toHex();     // returns a hex represetation of the value
+result.toHuman();   // returns human-friendly object representation of the value
+result.toString();  // returns a string representation of the value
+result.toU8a();     // encodes the value as a Unit8Array
+result.toJSON();    // converts the value to JSON
 ```

--- a/docs/api/read-state.md
+++ b/docs/api/read-state.md
@@ -7,34 +7,38 @@ sidebar_label: Read State
 
 There are two different ways to query the program `State`:
 
-1. Query the full `State` of the program. To read the full `State` of the program, you need to have only the `metadata` of this program. You can call `api.programState.read` method to get the state.
+1. Query the full `State` of the program. To read the full `State` of the program, you need to have only the `metadata` of this program. You can call `gearApi.programState.read` method to get the state.
 
 ```javascript
-await api.programState.read({ programId: `0x...` }, programMetadata);
+import { GearApi } from '@gear-js/api';
+const gearApi = await GearApi.create({
+  providerAddress: 'wss://testnet.vara.rs',
+});
+await gearApi.programState.read({ programId: '0x…' }, programMetadata);
 ```
 
-Also, you can read the `State` of the program at some specific block:
+Also, you can read the `State` of the program at some specific block specified by its hash:
 
 ```javascript
-await api.programState.read(
-  { programId: `0x...`, at: `0x...` },
+await gearApi.programState.read(
+  { programId: '0x…', at: '0x…' },
   programMetadata,
 );
 ```
 
-2. If you are using the custom functions to query only specific parts of the program State ([see more](/docs/developing-contracts/metadata#genarate-metadata)), then you should to call `api.programState.readUsingWasm` method:
+2. If you are using the custom functions to query only specific parts of the program State ([see more](/docs/developing-contracts/metadata#genarate-metadata)), then you should call `GearApi.programState.readUsingWasm` method:
 
 ```js
 // ...
+import { getStateMetadata } from '@gear-js/api';
+const stateWasm = readFileSync('path/to/state.meta.wasm');
+const metadata = await getStateMetadata(stateWasm);
 
-const wasm = readFileSync('path/to/state.meta.wasm');
-const metadata = await getStateMetadata(wasm);
-
-const state = await api.programState.readUsingWasm(
+const state = await gearApi.programState.readUsingWasm(
   {
-    programId,
+    programId: '0x…',
     fn_name: 'name_of_function_to_execute',
-    wasm,
+    stateWasm,
     argument: { input: 'payload' },
   },
   metadata,
@@ -54,14 +58,14 @@ const buffer = await Buffer.from(arrayBuffer);
 const metadata = await getStateMetadata(buffer);
 
 // get State only of the first wallet
-const firstState = await api.programState.readUsingWasm(
-  { programId, fn_name: 'first_wallet', buffer },
+const firstState = await gearApi.programState.readUsingWasm(
+  { programId: '0x…', fn_name: 'first_wallet', buffer },
   metadata,
 );
 
 // get wallet State by id
-const secondState = await api.programState.readUsingWasm(
-  { programId, fn_name: 'wallet_by_id', buffer,  argument: { decimal: 1, hex: '0x01' } },
+const secondState = await gearApi.programState.readUsingWasm(
+  { programId: '0x…', fn_name: 'wallet_by_id', buffer,  argument: { decimal: 1, hex: '0x01' } },
   metadata,
 );
 

--- a/docs/api/send-message.mdx
+++ b/docs/api/send-message.mdx
@@ -5,7 +5,7 @@ sidebar_label: Send Message
 
 # Send Message
 
-Use `api.message.send` method to send messages to the program:
+Use `GearApi.message.send` method to send messages to the program:
 
 ```javascript
 try {
@@ -33,14 +33,14 @@ try {
 
 :::note
 
-In real conditions to ensure successful message processing, the calculation of the required gas for processing the message should be performed by using `api.program.calculateGas` method.
+In real conditions to ensure successful message processing, the calculation of the required gas for processing the message should be performed by using `GearApi.program.calculateGas` method.
 
 [more info](/docs/api/calculate-gas)
 :::
 
 ### Send reply message
 
-When you need to reply to a message received from a program, use `api.message.reply`:
+When you need to reply to a message received from a program, use `GearApi.message.reply`:
 
 ```javascript
 try {

--- a/docs/api/submit-code.md
+++ b/docs/api/submit-code.md
@@ -1,11 +1,11 @@
 ---
 sidebar_position: 5
-sidebar_label: Upload code
+sidebar_label: Upload Code
 ---
 
 # Upload code
 
-If you need to load the program code into the chain without initialization use `api.code.upload` method to create `upload_code` extrinsic:
+If you need to load the program code into the chain without initialization use `GearApi.code.upload` method to create `upload_code` extrinsic:
 
 ```javascript
 const code = fs.readFileSync('path/to/program.opt.wasm');
@@ -25,10 +25,10 @@ gearApi.code.signAndSend(alice, () => {
 
 ## Create program from uploaded code on chain
 
-Use `api.program.create` method to create `create_program` extrinsic:
+Use `GearApi.program.create` method to create `create_program` extrinsic:
 
 ```javascript
-const codeId = '0x...';
+const codeId = '0x…';
 
 const program = {
   codeId,

--- a/docs/api/tooling/create-gear-app.md
+++ b/docs/api/tooling/create-gear-app.md
@@ -9,7 +9,7 @@ Introducing Gear React Application Template: Accelerate Your Decentralized App D
 
 Are you looking to swiftly launch your decentralized application (dApp) on Gear-powered blockchains? Look no further! Gear React Application Template, also known as `create-gear-app`, is a pre-configured application template designed to streamline the development process. With its well-thought-out infrastructure and convenient features, it allows developers to quickly create and deploy their dApps on Gear-powered blockchains.
 
-Gear React Application Template can be found on [GitHub](hhttps://github.com/gear-dapps/react-app). This template is packed with a range of benefits and features that make it an ideal choice for developers seeking efficiency and simplicity in their dApp development workflow.
+Gear React Application Template can be found on [GitHub](https://github.com/gear-dapps/react-app). This template is packed with a range of benefits and features that make it an ideal choice for developers seeking efficiency and simplicity in their dApp development workflow.
 
 ## Features
 

--- a/docs/api/tooling/meta-cli.md
+++ b/docs/api/tooling/meta-cli.md
@@ -3,6 +3,14 @@ sidebar_position: 2
 sidebar_label: Meta CLI
 ---
 
+:::warning Deprecation Notice
+
+This CLI tool is deprecated and will be removed in the future.
+
+Please use `getProgramMetadata` from `@gear-js/api` instead as described [here](/docs/api/metadata-type-creation.md).
+
+:::
+
 # Gear Meta CLI
 
 CLI tool to encode/decode payloads and work with .meta.wasm files.
@@ -21,7 +29,7 @@ yarn global add @gear-js/gear-meta
 
 ## Usage
 
-### Full list of commmands
+### Full list of commands
 
 ```sh
 gear-meta --help

--- a/docs/api/tooling/react-hooks.md
+++ b/docs/api/tooling/react-hooks.md
@@ -7,7 +7,7 @@ sidebar_label: React-hooks
 
 Hooks allow functional components to have access to programs running on Gear networks and significantly simplify the development of front-end applications.
 
-For example, refer to [this article](./../../examples/nft-marketplace/nft-application) that demonstrates the creation of a React application that connects to an [NFT smart contract](./../../examples/gnft-721) running on the blockchain.
+For example, refer to [this article](/examples/nft-marketplace/nft-application.md) that demonstrates the creation of a React application that connects to an [NFT smart contract](/examples/gnft-721.md) running on the blockchain.
 
 ## Installation
 
@@ -23,7 +23,7 @@ yarn add @gear-js/react-hooks
 
 ## Getting started
 
-Simple as it is, here's quick example:
+Simple as it is, here's a quick example:
 
 ```jsx
 import { useReadFullState } from '@gear-js/react-hooks';
@@ -46,12 +46,12 @@ export { State };
 ## Cookbook
 
 :::info
-In order for these hooks to work, the application must be wrapped in the appropriate Providers. As it is presented in the [example](https://github.com/gear-tech/gear-js/blob/main/utils/create-gear-app/gear-app-template/template/src/hocs/index.tsx). If you use `cga`, then all the necessary environment has already been provided.
+In order for these hooks to work, the application must be wrapped in the appropriate Providers. As it is presented in the [example](https://github.com/gear-tech/gear-js/blob/main/utils/create-gear-app/gear-app-template/template/src/hocs/index.tsx). If you use `create-gear-app`, then all the necessary environment has already been provided.
 :::
 
 ### useApi
 
-`useApi` provides access to the Gear API connected to the selected PRC-node.
+`useApi` provides access to the Gear API connected to the selected RPC-node.
 
 ```js
 import { useApi } from '@gear-js/react-hooks';
@@ -61,7 +61,7 @@ const { api, isApiReady } = useApi();
 
 ### useAccount
 
-`useAccount` provides interaction with `Polkadot-js` extension api, allows to manage accounts from it (for example to sign transaction).
+`useAccount` provides interaction with `Polkadot-js` extension API, allows to manage accounts from it (for example to sign transactions).
 
 ```js
 import { useAccount } from '@gear-js/react-hooks';
@@ -84,7 +84,7 @@ alert.success('success message')
 
 ### useMetadata
 
-This hook is auxiliary and it is not pre-installed in the react-hook library. `useMetadata` allows to convert program's metadata (`.txt` file) into the required format.
+This hook is auxiliary and it is not pre-installed in the react-hook library. `useMetadata` allows converting the program's metadata (`.txt` file) into the required format.
 
 ```js
 import { useEffect, useState } from 'react';
@@ -173,7 +173,7 @@ function readFullState() {
 
 ### useReadWasmState
 
-`useReadWasmState` allows reading program State using specific functions.
+`useReadWasmState` allows reading program `State` using specific functions.
 
 ```js
 import { useReadWasmState } from '@gear-js/react-hooks';

--- a/docs/api/tooling/react-hooks.md
+++ b/docs/api/tooling/react-hooks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 sidebar_label: React-hooks
 ---
 

--- a/docs/api/upload-program.md
+++ b/docs/api/upload-program.md
@@ -7,7 +7,7 @@ sidebar_label: Upload Program
 
 A smart contract compiled to Wasm can be uploaded to the Gear network as a program. During uploading it is initialized in the network to be able to send and receive messages with other actors in the network (programs and users).
 
-Use `api.program.upload` method to create `upload_program` extrinsic
+Use `GearApi.program.upload` method to create `upload_program` extrinsic
 
 ```javascript
 const code = fs.readFileSync('path/to/program.wasm');
@@ -39,7 +39,7 @@ try {
 
 :::note
 
-For the calculation of the required gas for `init` message processing should use `api.program.calculateGas.initUpload()` method.
+For the calculation of the required gas for `init` message processing should use `GearApi.program.calculateGas.initUpload()` method.
 
 [more info](/docs/api/calculate-gas)
 :::

--- a/docs/examples/monopoly.md
+++ b/docs/examples/monopoly.md
@@ -40,13 +40,13 @@ There are two ways to upload the game onto the chain:
     - Local node - ws://localhost:9944
 - Upload Master and Player contracts:
     - Click the `Upload Program` button and specify `x.opt.wasm` file of the program, also specify the `*.txt` file with metadata for Master and Palyer contracts accordingly.
-    - Save the addresses of the uploaded programs. 
-- Make gas reservations to ensure continuous game execution. 
+    - Save the addresses of the uploaded programs.
+- Make gas reservations to ensure continuous game execution.
     - Find your uploaded Master contract and click the `Send message` button:
     ![img alt](./img/monopoly-gas-reserve.png)
     - Currently the single gas reservation amount can be up to 245 000 000 000 since it is not yet possible to make a reservation more than the block gas limit (250 000 000 000). To make sure the Master contract has enough gas to run and complete the game, it is recommended to make at least 5-10 reservations.
 
-### 2. Using [`gear-js/cli`](https://github.com/gear-tech/gear-js/tree/main/tools/cli) 
+### 2. Using [`gear-js/cli`](https://github.com/gear-tech/gear-js/tree/main/tools/cli)
 
 It allows sending transactions to the Gear node based on `yaml` file:
 - Go to folder with [scripts](https://github.com/gear-dapps/syndote/tree/master/upload-game):
@@ -54,12 +54,12 @@ It allows sending transactions to the Gear node based on `yaml` file:
     cd ./upload-game/
     ```
 - Upload previously built files into `/programs` folder (replace if necessary): `player.meta.txt`, `syndote.meta.txt`, `player.opt.wasm`, `syndote.opt.wasm`
-    
+
 - Install `gear-js/cli`:
     ```
     npm install -g @gear-js/cli
     ```
-- Upload the master contract. The `upload-game.yaml` file contains a transaction that will deploy the contract onto the network, check [README](https://github.com/gear-tech/gear-js/tree/main/tools/cli) for more details. 
+- Upload the master contract. The `upload-game.yaml` file contains a transaction that will deploy the contract onto the network, check [README](https://github.com/gear-tech/gear-js/tree/main/tools/cli) for more details.
 
 - Customize the following parameters:
 
@@ -68,44 +68,44 @@ It allows sending transactions to the Gear node based on `yaml` file:
     	accounts:
   		alice: 'bottom drive obey lake curtain smoke basket hold race lonely fit walk'
 		bob: //Bob
-		my_account: '0x...seed'
+		my_account: '0x…seed'
     	transactions:
 		account: alice
     	```
-    
+
     - You can also specify which node you want to deploy the contract on by defining the variable `wsAddress` in the file with transactions. If this variable is not defined, the contract will be deployed on the local node which should be running beforehand:
     	```
     	wsAddress: wss://node-workshop.gear.rs
     	```
-    
+
 - To deploy the contract, run the command:
     ```
     gear-js workflow upload-game.yaml
     ```
-    
+
 - If everything goes well, you will see the contract address in the terminal:
     ![img alt](./img/upload-game.png)
-    
+
 - To run the application, it is necessary to save this address and later specify it as a variable in the `.env` file.
- 
+
 - Make gas reservations to ensure continuous game execution. Open `reserve-gas.yaml` file and customize account and node address as described above. Run the command with the master contract address specified:
     ```
     gear-js workflow reserve-gas.yaml -a program_id='0x60663aaee2971eb60874b63c92e738cc375f3764a1d3b38d65cbc63d8ee8f70c'
     ```
-    
+
 - If everything goes well, you will see a message confirming a successful reservation. Please send this message 5-10 times to ensure uninterrupted gameplay.
-    
+
     ![img alt](./img/reserve_gas.png)
 
 - Upload players contracts to the network. For testing purposes, you can upload 4 identical player contracts. After initialization in the network, their addresses will be unique and you will then need to register them in the game. Open `players.yaml` file and customize account and node address as described above. Run the command to add players in the game:
     ```
     gear-js workflow players.yaml
     ```
-    
+
 - You will see the players addresses:
     ![img alt](./img/players.png)
-    
-- Additionally, you can write your own player contract, build it, and place the `.opt.wasm` and `.meta.txt` files into the `upload-game/programs` folder. 
+
+- Additionally, you can write your own player contract, build it, and place the `.opt.wasm` and `.meta.txt` files into the `upload-game/programs` folder.
     To deploy your player, specify the necessary files in the `players.yaml` file instead of any existing player.
     ![img alt](./img/my_player.png)
 
@@ -118,7 +118,7 @@ yarn install
 ```
 3. Declare environment variables, go to `/frontend/` foler, create new `.env` file, check `.env.example` file to get necessary variables:
     - `REACT_APP_SYNDOTE_NODE_ADDRESS` - in this parameter specify the address of the node on which you deployed the contracts.
-    - `REACT_APP_CONTRACT_ADDRESS` - in this parameter specify the address of the deployed master contract. 
+    - `REACT_APP_CONTRACT_ADDRESS` - in this parameter specify the address of the deployed master contract.
 4. Put the latest version of the `syndote.meta.txt` file locally in `src/assets/wasm/` folder, replace if necessary.
 
 :::note
@@ -132,7 +132,7 @@ yarn start
 ```
 
 ## Run the game
-1. Find the players addresses you have prevously uploaded. 
+1. Find the players addresses you have prevously uploaded.
 
 2. Register players in the application's interface one after another. Each player registration is a transaction that needs to be signed. It is possible to register up to 4 players.
 

--- a/docs/gear-networks/vara-intro.md
+++ b/docs/gear-networks/vara-intro.md
@@ -22,4 +22,4 @@ There are several ways other than developing and running dApps to support Vara N
 - Become a Nominator by staking tokens and nominating validators. Elected validators that produce blocks redistribute rewards to their nominators.
 - Become Ambassador to create educational awareness, community engagement, and decentralization around Vara Network and Gear Protocol.
 
-For more info about Vara Network and how to become a part of community, refer to **[Vara Wiki](https://wiki.vara-network.io/)**.
+For more info about Vara Network and how to become a part of the community, refer to **[Vara Wiki](https://wiki.vara-network.io/)**.

--- a/docs/gear/distinctive-features.md
+++ b/docs/gear/distinctive-features.md
@@ -7,7 +7,7 @@ sidebar_label: Gear Distinctive Features
 
 ## Truly decentralized
 
-One of the well-known drawbacks of other-platform’s smart contracts is that they cannot trigger their own functions. Instead, to run certain functions they require an external component or service to trigger on-chain transactions.
+One of the well-known drawbacks of other platforms' smart contracts is that they cannot trigger their own functions. Instead, to run certain functions they require an external component or service to trigger on-chain transactions.
 
 While some smart contract logic may rely on users to initiate transactions and awaken the contract, many cases require a trigger when certain conditions are met, such as reaching a specific point in time or the occurrence of a particular event. In the past, this has either limited the capabilities of smart contracts or required developers to introduce a centralized service to trigger smart contracts.
 
@@ -17,7 +17,7 @@ Now thanks to Gear Protocol's support for asynchronous messaging, contract devel
 
 The execution of any messages in Gear, including the [system messages](/developing-contracts/system-signals.md), consumes "gas". The Gear Protocol introduces the concept of [gas reservation](/developing-contracts/gas-reservation.md), which allows for the creation of gas pools that can be used by programs for further execution. Each pool is unique to the program that creates it, and the gas from the pool can be consumed by the program if its "gas_available" is not sufficient.
 
-One of the key benefits of gas reservation is the ability to send **delayed messages** that can be triggered automatically at a specific time in the future. These messages, like any other message in Gear, can invoke another smart contract in the network or appear in the user's mailbox.
+One of the key benefits of the gas reservation is the ability to send **delayed messages** that can be triggered automatically at a specific time in the future. These messages, like any other message in Gear, can invoke another smart contract in the network or appear in the user's mailbox.
 
 Perhaps most interestingly, gas reservation allows a program to send a message to itself at a later time, allowing it to continue execution after a defined period. This effectively enables a smart contract to execute itself an **unlimited** number of times (provided that enough gas is available for the execution).
 
@@ -44,7 +44,7 @@ Overall, the ability to update NFTs dynamically opens up a wide range of possibi
 
 Tamagotchi is a classic digital pet game where players must care for a virtual creature by providing it food, attention, and other forms of care. As a dynamic NFT, a Tamagotchi can change its appearance based on its properties (such as hunger, fatigue, or happiness) and can notify the user when it needs to be fed or played with. The user can feed the NFT with gas, which is used to send delayed messages that are required to update the Tamagotchi's state.
 
-"Game strategies battle" is a game in which several programs compete with each other using different algorithms or strategies. The game can be based on a variety of classic games, such as checkers, tic-tac-toe, races, or monopoly. Each participant creates a smart contract with their own game strategy and uploads it to the blockchain. The programs then play against each other until someone wins or the gas runs out. If the gas runs out, one of the participants can continue the game by sending a message with more gas. This allows the game to continue indefinitely, with the most effective strategy ultimately emerging as the winner.
+"Game strategies battle" is a game in which several programs compete with each other using different algorithms or strategies. The game can be based on a variety of classic games, such as checkers, tic-tac-toe, races, or Monopoly. Each participant creates a smart contract with their own game strategy and uploads it to the blockchain. The programs then play against each other until someone wins or the gas runs out. If the gas runs out, one of the participants can continue the game by sending a message with more gas. This allows the game to continue indefinitely, with the most effective strategy ultimately emerging as the winner.
 
 ### DeFi
 

--- a/docs/gear/glossary.md
+++ b/docs/gear/glossary.md
@@ -7,7 +7,7 @@ sidebar_label: Glossary
 
 ### Account
 
-In cryptocurrency systems, a user is represented by an account that has address(es) with specific balances associated with their address. Besides that, an account can contain additional details such as contact information, eligibility for rewards, and more.
+In cryptocurrency systems, a user is represented by an account that has an address(es) with specific balances associated with their address. Besides that, an account can contain additional details such as contact information, eligibility for rewards, and more.
 
 ### Actor
 
@@ -71,15 +71,15 @@ A list of entries containing transactions signed by account owners. A blockchain
 
 ### Memory Parallelism
 
-Memory-level parallelism is a term in computer architecture referring to the ability to have pending multiple memory operations, in particular cache misses or translation lookaside buffer misses, at the same time.
+Memory-level parallelism is a term in computer architecture referring to the ability to have pending multiple memory operations, in particular, cache misses or translation lookaside buffer misses, at the same time.
 
 ### Node
 
 A computer device that runs on a blockchain network for message processing; it can also be a validator (block producer). Node makes the information available to everyone via a connected device.
 
-### Non Fungible Tokens (NFTs)
+### Non-Fungible Tokens (NFTs)
 
-A Non Fungible Token is a unique unit of data that’s represented as a cryptographic token that’s stored on a blockchain.
+A Non-Fungible Token is a unique unit of data that’s represented as a cryptographic token that’s stored on a blockchain.
 
 ### Parachain
 
@@ -111,7 +111,7 @@ Substrate is the modular framework for building customized blockchains and the f
 
 ### Transaction
 
-A record in a digital ledger that represents an atomic event in a blockchain. In case of Gear Protocol transactions can be 4 types: create a program; send a message; dequeue messages; balance transfers.
+A record in a digital ledger that represents an atomic event in a blockchain. In the case of Gear Protocol transactions can be of four types: create a program; send a message; dequeue messages; balance transfers.
 
 ### Validator
 
@@ -127,4 +127,6 @@ Web3 is the third evolution of the internet that is heavily supported by blockch
 
 ### WebAssembly (Wasm)
 
-WebAssembly is a way to run applications in programming languages other than JavaScript as web pages. Essentially, Wasm is just a virtual machine that runs on all modern browsers. But whereas in the past you were required to use JavaScript to run code in a web page, Wasm makes it possible to run code in browsers with programming languages other than JavaScript.
+WebAssembly is a way to run applications in programming languages other than JavaScript as web pages. Essentially, Wasm is just a binary code format to be executed on a virtual machine that runs on all modern browsers. But whereas in the past you were required to use JavaScript to run code on a web page, Wasm makes it possible to run code in browsers written in programming languages other than JavaScript.
+
+While the first implementations of Wasm virtual machines have landed in web browsers, there are also non-browser implementations for general-purpose use, including [Wasmer](https://wasmer.io/), [Wasmtime](https://wasmtime.dev/), etc.

--- a/docs/gear/why.md
+++ b/docs/gear/why.md
@@ -1,12 +1,11 @@
 ---
 title: Why do we build Gear?
 sidebar_position: 1
-sidebar_label: Why do we build Gear?
 ---
 
 ## Global aspect
 
-Blockchain technology launched a rapid transition from centralized, server-based internet (Web2) to a decentralized, distributed one (Web3). Its distinctive features are: no single point of failure (the network can still function even if a large proportion of participants are attacked/taken out), censorship resistance, anyone in the network has the possibility to use the service (permissionless).
+Blockchain technology launched a rapid transition from a centralized, server-based internet (Web2) to a decentralized, distributed one (Web3). Its distinctive features are: no single point of failure (the network can still function even if a large proportion of participants are attacked/taken out), censorship resistance, anyone in the network has the possibility to use the service (permissionless).
 
 Web3 introduces new types of decentralized applications (dApps) and assets such as: decentralized finances (DeFi), decentralized currency exchanges (DEX), decentralized marketplaces and gaming platforms, NFTs, Social Tokens and more.
 
@@ -22,11 +21,11 @@ Networks that were at the dawn of blockchain technology have a number of signifi
 - Lack of scalability, low transaction speed, high transaction costs - all of it hinders the growth of applications in Web3
 - Domain-specific development languages lead to high barriers to entry. The need to learn new programming language and paradigms holds back the growth of developers entering Web3
 - Complex and inefficient native consensus protocols
-- Absence of intercommunication between networks 
+- Absence of intercommunication between networks
 
 ## Dotsama ecosystem (Polkadot/Kusama networks)
 
-The solution has been found in Parity technologies, who’re focused on creating a Layer-0 technology that connects blockchains together into one big network - Polkadot.
+The solution has been found in Parity Technologies, which is focused on creating a Layer-0 technology that connects blockchains together into one big network - Polkadot.
 
 Polkadot provides a system in which blockchains coexist and complement each other. Different parallel blockchains (parachains) are built on Substrate as well as Polkadot and connected to the relay chain and have a native connection.This allows for different nodes to run different application logic, keeping each chain on its own platform. All parachains are interconnected, creating a massive network of multifunctional blockchain services. Parachains compose the Layer-1 of the Polkadot ecosystem, the main difference in connection with other standalone Layer-1 blockchain networks like Ethereum, Bitcoin, Solana, etc. is that parachains are connected through Substrate Cumulus library and standalone blockchains through bridges.
 
@@ -49,7 +48,7 @@ There are several components in the Polkadot architecture, namely:
 
 Relay Chain is the heart of Polkadot, responsible for the network’s security, consensus and cross-chain interoperability. It allows specialized blockchains and public blockchains to connect within the unified and interoperable Polkadot network. The Relay Chain can be understood as a Layer-0 platform.
 
-The Relay Chain has minimal functionality, which naturally means that advanced functionality features, like smart contracts for example, are not supported. Other specific work is delegated to the parachains, which each have different implementations and features.
+The Relay Chain has minimal functionality, which naturally means that advanced functionality features, like smart contracts, for example, are not supported. Other specific work is delegated to the parachains, which each have different implementations and features.
 
 The main task of the Relay Chain is to coordinate the overall system and its connected parachains to build a scalable and interoperable network.
 
@@ -61,7 +60,7 @@ Parachains are sovereign blockchains that can have their own tokens and optimize
 
 Parachains must be connected to the Relay Chain to ensure interoperability with other networks. For this, parachains lease a slot for continuous connectivity or they can pay as they go (in this case they are called Parathreads). Parachains compose the Layer-2 of the Polkadot ecosystem.
 
-Parachains are validateable by validators of the Relay Chain and they get their name from the concept of paralleziable chains that run parallel to the main Relay Chain. Due to their parallel nature, they are able to parallelize transaction processing which helps improve scalability of the Polkadot network.
+Parachains are validatable by validators of the Relay Chain and they get their name from the concept of parallelizable chains that run parallel to the main Relay Chain. Due to their parallel nature, they are able to parallelize transaction processing which helps improve the scalability of the Polkadot network.
 
 Parachains optimize their functionality for specific use cases and, in many instances, support their own tokens.
 

--- a/docs/idea/idea-overview.md
+++ b/docs/idea/idea-overview.md
@@ -7,15 +7,15 @@ sidebar_position: 1
 
 Gear IDEA is a convenient tool that’s purpose is to familiarize users with the Gear platform. It provides smart-contract developers with the easiest and fastest way to write, compile, test and upload smart-contracts to a test network directly in their browser without additional configuration.
 
-This is the demo application that implements all of the possibilities of interaction with smart-contracts in Gear, that also manages accounts, balances, events and more.
+This is the demo application that implements all of the possibilities of interaction with smart-contracts in Gear, which also manages accounts, balances, events and more.
 
-You can start experimenting right now on https://idea.gear-tech.io/.
+You can start experimenting right now at https://idea.gear-tech.io/.
 
 # IDEA components and microservices
 
 [frontend](https://github.com/gear-tech/gear-js/tree/main/idea/frontend)
 
-React application that provides user interface for working with smart-contracts on Gear IDEA.
+React application that provides the user interface for working with smart-contracts on Gear IDEA.
 
 [indexer](https://github.com/gear-tech/gear-js/tree/master/idea/indexer)
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,7 +1,6 @@
 ---
 title: Welcome!
 sidebar_position: 1
-sidebar_label: Welcome!
 slug: /
 ---
 
@@ -9,7 +8,7 @@ Welcome to Gear’s documentation portal. This is the central source of informat
 
 Our Wiki outlines foundational information required, general technology overviews and key advantages of Gear’s technology, including how to implement and run your smart contracts and how to get started with the Gear node setup, while also providing full API details and examples.
 
-All code, libraries, and tools are available on Github with a permissive Apache-2.0 license. Feel free to use the tools and libraries, log issues as you find them, or create pull requests for your bug-bears or features.
+All code, libraries, and tools are available on GitHub. Feel free to use the tools and libraries, log issues as you find them, or create pull requests for your bug-bears or features.
 
 As our project is developing and growing, contributions are more than welcome!
 
@@ -31,11 +30,11 @@ The Gear Protocol provides the most cost-effective way to run smart contracts. P
 
 ### GitHub
 
-Instructions and other development-focused conversation is found on our [GitHub](https://github.com/gear-tech).
+Instructions and other development-focused conversations are found on our [GitHub](https://github.com/gear-tech).
 
 ### Discord
 
-General information and non-technical conversation is found on our [Discord server](https://discord.gg/7BQznC9uD9).
+General information and non-technical conversation are found on our [Discord server](https://discord.gg/7BQznC9uD9).
 
 ### Twitter
 

--- a/docs/node/dev-net.md
+++ b/docs/node/dev-net.md
@@ -14,7 +14,7 @@ To run the Gear node in a dev net mode:
 2. Run the node in dev mode (we assume the executable is in `/usr/bin` directory):
 
 ```bash
-gear --dev --tmp
+gear --dev
 ```
 
 3. Follow https://idea.gear-tech.io/ and connect to a local dev node. Click network selection via the left top button, choose Development -> Local node, and click the Switch button. Use the Idea portal for sending messages, reading the program's state, etc.

--- a/docs/node/node-as-service.md
+++ b/docs/node/node-as-service.md
@@ -100,9 +100,7 @@ After the node has been running for a while, you may need to update it to the la
 You just need to replace the node executable (`gear`) with the latest version and restart the execution. For example, if your Linux executable is located at `/usr/bin/gear` (as we've configured above) you are to run:
 
 ```
-wget https://get.gear.rs/gear-nightly-x86_64-unknown-linux-gnu.tar.xz
-sudo tar -xvf gear-nightly-x86_64-unknown-linux-gnu.tar.xz -C /usr/bin
-rm gear-nightly-x86_64-unknown-linux-gnu.tar.xz
+curl https://get.gear.rs/gear-nightly-x86_64-unknown-linux-gnu.tar.xz | sudo tar -xJC /usr/bin
 sudo systemctl restart gear-node
 ```
 

--- a/docs/node/setting-up.mdx
+++ b/docs/node/setting-up.mdx
@@ -34,9 +34,7 @@ Depending on your OS you need to download nightly build of Gear node:
 Terminal:
 
 ```bash
-wget https://get.gear.rs/gear-nightly-linux-x86_64.tar.xz && \
-tar xvf gear-nightly-linux-x86_64.tar.xz && \
-rm gear-nightly-linux-x86_64.tar.xz
+curl https://get.gear.rs/gear-nightly-linux-x86_64.tar.xz | tar xJ
 ```
 
 or
@@ -57,9 +55,7 @@ gear 0.1.0-hashcode
 Terminal:
 
 ```bash
-wget https://get.gear.rs/gear-nightly-aarch64-apple-darwin.tar.xz && \
-tar xvf gear-nightly-aarch64-apple-darwin.tar.xz && \
-rm gear-nightly-aarch64-apple-darwin.tar.xz
+curl https://get.gear.rs/gear-nightly-aarch64-apple-darwin.tar.xz | tar xJ
 ```
 
 or
@@ -79,9 +75,7 @@ gear 0.1.0-hashcode
 Terminal:
 
 ```bash
-wget https://get.gear.rs/gear-nightly-x86_64-apple-darwin.tar.xz && \
-tar xvf gear-nightly-x86_64-apple-darwin.tar.xz && \
-rm gear-nightly-x86_64-apple-darwin.tar.xz
+curl https://get.gear.rs/gear-nightly-x86_64-apple-darwin.tar.xz | tar xJ
 ```
 
 or
@@ -126,7 +120,7 @@ Compiling the build will take some time and requires the installation of some de
 
 :::warning Note
 Windows users may encounter some problems related to the installation of Rust components and dependencies.
-It is highly recommended to use Linux or macOS for compiling Gear node and smart-contracts. 
+It is highly recommended to use Linux or macOS for compiling Gear node and smart-contracts.
 :::
 
 ### Prerequisites
@@ -171,7 +165,8 @@ cd gear
 git checkout testnet
 
 ## Optional
-## If you need to use the latest or experimental Gear functions, you should compile `gear-node` from `master` branch
+## If you need to use the latest or experimental Gear functions,
+## you should compile `gear-node` from `master` branch.
 ```
 
 ### Compile
@@ -213,7 +208,7 @@ It doesn't matter if you downloaded the prebuild binary or built it yourself. Be
 To run Gear node in dev mode use the following command:
 
 ```bash
-./gear --dev --tmp
+./gear --dev
 ```
 
 ## Command Flags and Options
@@ -229,10 +224,6 @@ gear [subcommand] [options]
 - `--dev`
 
   Run standalone node of Gear network.
-
-- `--tmp`
-
-  Run node with a temporary storage. A temporary directory will be created to store the configuration and will be deleted at the end of the process.
 
 - `purge-chain`
 

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/api/events.mdx
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/api/events.mdx
@@ -175,7 +175,7 @@ import { UnsubscribePromise } from '@polkadot/api/types';
 export function waitForInit(api: GearApi, programId: string): Promise<UnsubscribePromise> {
   let messageId: Hex;
   return new Promise((resolve, reject) => {
-    const unsub = api.query.system.events((events) => {
+    const unsub = gearApi.query.system.events((events) => {
       events.forEach(({ event }) => {
         switch (event.method) {
           case 'MessageEnqueued':

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/api/extra-queries.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/api/extra-queries.md
@@ -66,10 +66,10 @@ extrinsics.forEach((extrinsic) => {
 ## Get transaction fee 获取
 
 ```javascript
-const api = await GearApi.create();
+const gearApi = await GearApi.create();
 api.program.submit({ code, gasLimit });
-// same for api.message, api.reply and others
-const paymentInfo = await api.program.paymentInfo(alice);
+// same for gearApi.message, gearApi.reply and others
+const paymentInfo = await gearApi.program.paymentInfo(alice);
 const transactionFee = paymentInfo.partialFee.toNumber();
 consolg.log(transactionFee);
 ```

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/api/mailbox.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/api/mailbox.md
@@ -10,26 +10,26 @@ mailbox 用于存储从程序发送至用户的信息。
 ## 从 Mailbox 中读取信息
 
 ```javascript
-const api = await GearApi.create();
-const mailbox = await api.mailbox.read('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY');
+const gearApi = await GearApi.create();
+const mailbox = await gearApi.mailbox.read('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY');
 console.log(mailbox);
 ```
 
 ## Claim value
 
 ```javascript
-const api = await GearApi.create();
-const submitted = await api.mailbox.claimValue.submit(messageId);
-await api.mailbox.claimValue.signAndSend(...);
+const gearApi = await GearApi.create();
+const submitted = await gearApi.mailbox.claimValue.submit(messageId);
+await gearApi.mailbox.claimValue.signAndSend(/* ... */);
 ```
 
 ## 等待列表
 
-要读取程序的等待列表，可以使用 `api.waitlist.read` 方法。
+要读取程序的等待列表，可以使用 `GearApi.waitlist.read` 方法。
 
 ```javascript
 const gearApi = await GearApi.create();
-const programId = '0x1234...';
-const waitlist = await api.waitlist.read(programId);
+const programId = '0x1234…';
+const waitlist = await gearApi.waitlist.read(programId);
 console.log(waitlist);
 ```

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/api/metadata-type-creation.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/api/metadata-type-creation.md
@@ -18,7 +18,7 @@ sidebar_label: 元数据 与 Type Creation
 ```javascript
 import { getProgramMetadata } from '@gear-js/api';
 
-const metadata = getProgramMetadata(`0x...`);
+const metadata = getProgramMetadata('0x…');
 
 // 函数 getProgramMetadata() 以十六进制格式获取程序的元数据
 // 它返回一个 `ProgramMetadata` 类的对象，其属性 `types` 包含所有程序类型
@@ -51,7 +51,7 @@ metadata.functions; //  是一个对象，其键是函数名称，值是输入/�
 ```js
 import { ProgramMetadata } from '@gear-js/api`;
 
-const metadata = getProgramMetadata(`0x...`);
+const metadata = getProgramMetadata('0x…');
 
 // 返回具有此索引的类型的名称
 metadata.getTypeName(4);

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/api/read-state.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/api/read-state.md
@@ -8,22 +8,22 @@ sidebar_label: 读取状态
 
 有两种不同的方式查询程序的 `State`：
 
-1. 查询程序的完整 `State`。要读取程序的完整`State`，需要有这个程序的 `metadata`。你可以调用 `api.programState.read` 方法来获取状态。
+1. 查询程序的完整 `State`。要读取程序的完整`State`，需要有这个程序的 `metadata`。你可以调用 `GearApi.programState.read` 方法来获取状态。
 
 ```javascript
-await api.programState.read({ programId: `0x...` }, programMetadata);
+await gearApi.programState.read({ programId: '0x…' }, programMetadata);
 ```
 
 此外，你可以在一些特定的块上读取程序的 `State`：
 
 ```javascript
-await api.programState.read(
-  { programId: `0x...`, at: `0x...` },
+await gearApi.programState.read(
+  { programId: '0x…', at: '0x…' },
   programMetadata,
 );
 ```
 
-2. 如果你使用自定义函数只查询程序状态的特定部分（[更多内容](/docs/developing-contracts/metadata#genarate-metadata)），那么应该调用 `api.programState.readUsingWasm` 方法：
+2. 如果你使用自定义函数只查询程序状态的特定部分（[更多内容](/docs/developing-contracts/metadata#genarate-metadata)），那么应该调用 `GearApi.programState.readUsingWasm` 方法：
 
 ```js
 // ...
@@ -31,9 +31,9 @@ await api.programState.read(
 const wasm = readFileSync('path/to/state.meta.wasm');
 const metadata = await getStateMetadata(wasm);
 
-const state = await api.programState.readUsingWasm(
+const state = await gearApi.programState.readUsingWasm(
   {
-    programId,
+    programId: '0x…',
     fn_name: 'name_of_function_to_execute',
     wasm,
     argument: { input: 'payload' },
@@ -55,14 +55,14 @@ const buffer = await Buffer.from(arrayBuffer);
 const metadata = await getStateMetadata(buffer);
 
 // get State only of the first wallet
-const firstState = await api.programState.readUsingWasm(
-  { programId, fn_name: 'first_wallet', buffer },
+const firstState = await gearApi.programState.readUsingWasm(
+  { programId: '0x…', fn_name: 'first_wallet', buffer },
   metadata,
 );
 
 // get wallet State by id
-const secondState = await api.programState.readUsingWasm(
-  { programId, fn_name: 'wallet_by_id', buffer,  argument: { decimal: 1, hex: '0x01' } },
+const secondState = await gearApi.programState.readUsingWasm(
+  { programId: '0x…', fn_name: 'wallet_by_id', buffer,  argument: { decimal: 1, hex: '0x01' } },
   metadata,
 );
 

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/api/upload-program.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/api/upload-program.md
@@ -36,7 +36,7 @@ try {
 ```
 
 :::note
-对于计算`init`信息处理所需的 gas，应该使用`api.program.calculateGas.initUpload()`。
+对于计算`init`信息处理所需的 gas，应该使用`GearApi.program.calculateGas.initUpload()`。
 
 请看[更多相关信息](/api/calculate-gas)
 :::

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/examples/monopoly.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/examples/monopoly.md
@@ -36,7 +36,7 @@ Syndote 由 Master 合约和 Player 合约组成。主合约是启动和控制�
 [此处](https://get.gear.rs/) 可以找到 Gear 节点二进制执行文件。
 
 ```sh
-./gear --dev --tmp --unsafe-ws-external --rpc-methods Unsafe --rpc-cors all
+./gear --dev --unsafe-ws-external --rpc-methods Unsafe --rpc-cors all
 ```
 
 按照 [运行游戏](#running-the-game) 部分所述上传并运行 Master 和 Player 合约并注册玩家。

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/node/dev-net.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/node/dev-net.md
@@ -14,7 +14,7 @@ sidebar_position: 4
 2. 使用开发模式运行节点：
 
 ```bash
-./gear --dev --tmp
+./gear --dev
 ```
 
 3. 访问 https://idea.gear-tech.io/ 并连接到本地开发节点。通过左上方的按钮点击网络切换，选择 Development -> Local node，然后点击切换按钮。使用 Idea 发送消息，读取程序状态等。

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/node/setting-up.mdx
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/node/setting-up.mdx
@@ -176,7 +176,7 @@ cd target/release
 采用如下命令来运行开发模式的 Gear 节点：
 
 ```bash
-./gear --dev --tmp
+./gear --dev
 ```
 
 ## 命令标记和选项
@@ -192,10 +192,6 @@ gear [flags] [options]
 `--dev`
 
 运行单节点 Gear 开发网络。
-
-`--tmp`
-
-采用临时目录来运行节点。临时目录会被创建出来，用来存储配置信息，并且在进程结束时被删除。
 
 `purge-chain`
 


### PR DESCRIPTION
- Reviewed `gear-js` examples, fixed them, and added deprecation notice to `gear-meta` CLI (we can remove it, though).
- Many minor typos and misspellings.
- Shortened and simplified some commands.

[Rendered](https://deploy-preview-494--competent-kepler-ce8c2a.netlify.app/)