### PR TITLE
Update setting-up.mdx

### DIFF
--- a/docs/node/setting-up.mdx
+++ b/docs/node/setting-up.mdx
@@ -217,7 +217,7 @@ To run Gear node in dev mode use the following command:
 gear [subcommand] [options]
 ```
 
-- `--staging`
+- `--chain=staging`
 
   Connect the node to Gear testnet (default option).
 
@@ -227,7 +227,7 @@ gear [subcommand] [options]
 
 - `purge-chain`
 
-  Remove storage of the selected chain type. Needs to specify the chain connection type `--staging` or `--dev`
+  Remove storage of the selected chain type. Needs to specify the chain connection type `--chain=staging` or `--dev`
 
 - `help`, `--help`
 

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/node/setting-up.mdx
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/node/setting-up.mdx
@@ -185,7 +185,7 @@ cd target/release
 gear [flags] [options]
 ```
 
-`--staging`
+`--chain=staging`
 
 链接到 Gear 测试网。
 
@@ -195,7 +195,7 @@ gear [flags] [options]
 
 `purge-chain`
 
-删除选定链的存储。需要明确链的类型 `--staging` 或 `--dev`。
+删除选定链的存储。需要明确链的类型 `--chain=staging` 或 `--dev`。
 
 `--help`
 


### PR DESCRIPTION
`gear --staging` is now `gear --chain=staging`

```
$ gear --staging
error: unexpected argument '--staging' found
```
vs

```
$ gear --chain=staging
2023-06-23 09:04:20 Gear Node    
2023-06-23 09:04:20 ✌️  version 0.1.6-915832b154d    
2023-06-23 09:04:20 ❤️  by Gear Technologies, 2021-2023    
2023-06-23 09:04:20 📋 Chain specification: Gear Staging Testnet V7    
2023-06-23 09:04:20 🏷  Node name: cheap-rhythm-8818    
2023-06-23 09:04:20 👤 Role: FULL    
2023-06-23 09:04:20 💾 Database: RocksDb at /home/btwiuse/.local/share/gear/chains/gear_staging_testnet_v7/db/full    
2023-06-23 09:04:20 ⛓  Native runtime: gear-160 (gear-1.tx1.au1)
```

Updated sections:

-
-
-
